### PR TITLE
feat: add response entities

### DIFF
--- a/src/main/java/edu/apigestor/entity/response/AbstractResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/AbstractResponse.java
@@ -73,9 +73,9 @@ public abstract class AbstractResponse<T> {
    * @param id     identificador único da ocorrência desse erro.
    * @param status status HTTP desse erro.
    */
-  public void addError(long id, long status, String title) {
+  public void addError(long id, int status, String title) {
     this.error.put("id", Long.toString(id));
-    this.error.put("status", Long.toString(status));
+    this.error.put("status", Integer.toString(status));
     this.error.put("title", title);
     this.handleError();
   }

--- a/src/main/java/edu/apigestor/entity/response/AbstractResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/AbstractResponse.java
@@ -1,0 +1,100 @@
+package edu.apigestor.entity.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+/**
+ * A classe {@link AbstractResponse} representa a estrutura básica de uma resposta para qualquer
+ * solicitação realizada a API. Essa classe utiliza as especificações do JSON:API para construção
+ * das respostas. Instâncias das subclasses são convertidas automaticamente para JSON.
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see <a href="https://jsonapi.org/format/1.0/">JSON:API (1.0)</a>
+ */
+@JsonInclude(Include.NON_EMPTY)
+public abstract class AbstractResponse<T> {
+
+  private final Map<String, String> meta; // Contém meta-informações sobre a resposta.
+
+  private final Map<String, String> error; // Contém erros encontrados pela resposta.
+
+  public AbstractResponse() {
+    this.meta = new LinkedHashMap<>();
+    this.error = new LinkedHashMap<>();
+  }
+
+  /**
+   * Retorna um {@link Map} com os meta-dados dessa resposta.
+   *
+   * @return Mapa com meta-dados.
+   */
+  public Map<String, String> getMeta() {
+    return this.meta;
+  }
+
+  /**
+   * Retorna um {@link Map} com os erros dessa resposta. Se uma resposta possui erro, o método
+   * {@link AbstractResponse#getData()} deve retornar null ou um objeto vazio (i.e., mapa sem nenhum
+   * atributo).
+   *
+   * @return Mapa com meta-dados.
+   */
+  public Map<String, String> getError() {
+    return this.error;
+  }
+
+  /**
+   * Retorna os dados dessa resposta ou null (caso a solicitação tenha resultado em um erro).
+   *
+   * @return um objeto que contém os dados dessa resposta.
+   */
+  public T getData() {
+    return this.buildData();
+  }
+
+  /**
+   * Adiciona um meta-dado.
+   *
+   * @param key   chave de identificação do meta-dado.
+   * @param value valor do meta-dado.
+   */
+  public void addMetaInfo(String key, String value) {
+    this.meta.put(key, value);
+    this.handleMetaInfo();
+  }
+
+  /**
+   * Adiciona um erro.
+   *
+   * @param id     identificador único da ocorrência desse erro.
+   * @param status status HTTP desse erro.
+   */
+  public void addError(long id, long status, String title) {
+    this.error.put("id", Long.toString(id));
+    this.error.put("status", Long.toString(status));
+    this.error.put("title", title);
+    this.handleError();
+  }
+
+  /**
+   * Método que determina como a resposta deve tratar a ocorrência de um erro (i.e., adicionar
+   * meta-dados, não retornar dados, etc).
+   */
+  protected abstract void handleError();
+
+  /**
+   * Método que determina como a resposta deve tratar a adição de um novo meta-dado.
+   */
+  protected void handleMetaInfo() {
+    // Tratamento padrão para adição de meta-informações é vazio.
+  }
+
+  /**
+   * Método auxiliar que constrói o objeto que contém os dados dessa resposta.
+   */
+  protected abstract T buildData();
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosNacionalResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosNacionalResponse.java
@@ -1,0 +1,31 @@
+package edu.apigestor.entity.response;
+
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados gerais sobre a educação
+ * brasileira a nível nacional.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see HomeDadosResponse
+ */
+public class HomeDadosNacionalResponse extends HomeDadosResponse {
+
+  private String country = "Brasil"; // País padrão da resposta.
+
+  /**
+   * Adiciona o país dessa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosNacionalResponse country(String country) {
+    this.country = country;
+    return this;
+  }
+
+  @Override
+  protected Map<String, Object> additionalAttributes() {
+    return Map.of("country", this.country);
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosNacionalResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosNacionalResponse.java
@@ -17,6 +17,7 @@ public class HomeDadosNacionalResponse extends HomeDadosResponse {
   /**
    * Adiciona o país dessa resposta.
    *
+   * @param country nome do país.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosNacionalResponse country(String country) {

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosRegionalResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosRegionalResponse.java
@@ -1,0 +1,31 @@
+package edu.apigestor.entity.response;
+
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados gerais sobre a educação
+ * brasileira a nível regional.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see HomeDadosResponse
+ */
+public class HomeDadosRegionalResponse extends HomeDadosResponse {
+
+  private String region;
+
+  /**
+   * Adiciona a região dessa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosRegionalResponse region(String region) {
+    this.region = region;
+    return this;
+  }
+
+  @Override
+  protected Map<String, Object> additionalAttributes() {
+    return Map.of("region", this.region);
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosRegionalResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosRegionalResponse.java
@@ -17,6 +17,7 @@ public class HomeDadosRegionalResponse extends HomeDadosResponse {
   /**
    * Adiciona a região dessa resposta.
    *
+   * @param region nome da região.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosRegionalResponse region(String region) {

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -5,6 +5,14 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados gerais sobre a educação
+ * brasileira em algum nível (Nacional, Regional ou Estadual).</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see AbstractResponse
+ */
 public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Object>> {
 
   private static final String RESOURCE_TYPE = "eduData";
@@ -99,6 +107,13 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
 
   protected abstract Map<String, Object> additionalAttributes();
 
+  /**
+   * Define os dados que compõem uma resposta sobre os dados da educação brasileira. Todos
+   * representam uma média.
+   *
+   * @author moesiof
+   * @version 1.0
+   */
   private static class HomeDadosData {
 
     @JsonUnwrapped

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -25,6 +25,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona um identificador único para essa resposta.
    *
+   * @param id identificador.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse id(long id) {
@@ -35,6 +36,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o índice de Complexidade de Gestão médio.
    *
+   * @param icg ICG médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse icg(Double icg) {
@@ -45,6 +47,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o indicador de esforço docente médio.
    *
+   * @param ied IED médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse ied(Double ied) {
@@ -55,6 +58,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o indicador de adequação da formação docente médio.
    *
+   * @param afd AFD médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse afd(Double afd) {
@@ -65,6 +69,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o indicador de regularidade docente médio.
    *
+   * @param ird IRD médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse ird(Double ird) {
@@ -75,6 +80,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o indicador de distorção idade série médio.
    *
+   * @param tdi TDI médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse tdi(Double tdi) {
@@ -119,14 +125,14 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
     @JsonAnyGetter
     private Map<String, Object> others;
     @JsonProperty("ied")
-    private double meanIED; // esforço docente médio
+    private Double meanIED; // esforço docente médio
     @JsonProperty("ird")
-    private double meanIRD; // regularidade docente média
+    private Double meanIRD; // regularidade docente média
     @JsonProperty("tdi")
-    private double meanTDI; // distorção idade série média
+    private Double meanTDI; // distorção idade série média
     @JsonProperty("icg")
-    private double meanICG; // complexidade de gestão escolar média
+    private Double meanICG; // complexidade de gestão escolar média
     @JsonProperty("afd")
-    private double meanAFD; // adequação de formação docente média
+    private Double meanAFD; // adequação de formação docente média
   }
 }

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -1,0 +1,57 @@
+package edu.apigestor.entity.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Object>> {
+
+  private static final String RESOURCE_TYPE = "eduData";
+
+  private final HomeDadosData data = new HomeDadosData();
+  private long id; // identificar da resposta
+
+  private boolean hasError = false;
+
+  @Override
+  protected void handleError() {
+    this.hasError = true;
+  }
+
+  @Override
+  protected Map<String, Object> buildData() {
+    if (this.hasError) {
+      return null;
+    }
+
+    Map<String, Object> data = new LinkedHashMap<>();
+
+    data.put("type", HomeDadosResponse.RESOURCE_TYPE);
+    data.put("id", this.id);
+
+    this.data.others = this.additionalAttributes();
+
+    data.put("attributes", this.data);
+
+    return data;
+  }
+
+  protected abstract Map<String, Object> additionalAttributes();
+
+  private static class HomeDadosData {
+
+    @JsonUnwrapped
+    private Map<String, Object> others;
+    @JsonProperty("efd")
+    private double meanEFD; // esforço docente médio
+    @JsonProperty("ird")
+    private double meanIRD; // regularidade docente média
+    @JsonProperty("tdi")
+    private double meanTDI; // distorção idade série média
+    @JsonProperty("icg")
+    private double meanICG; // complexidade de gestão escolar média
+    @JsonProperty("afd")
+    private double meanAFD; // adequação de formação docente média
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -159,7 +159,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
      */
     private void addMeanIRD(Double meanIRD, String category) {
       this.ird.put("mean", meanIRD);
-      this.ied.put("meanCategory", category);
+      this.ird.put("meanCategory", category);
     }
 
     /**
@@ -170,7 +170,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
      */
     private void addMeanICG(Double meanICG, String category) {
       this.icg.put("mean", meanICG);
-      this.ied.put("meanCategory", category);
+      this.icg.put("meanCategory", category);
     }
 
     /**
@@ -181,7 +181,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
      */
     private void addMeanAFD(Double meanAFD, String category) {
       this.afd.put("mean", meanAFD);
-      this.ied.put("meanCategory", category);
+      this.afd.put("meanCategory", category);
     }
 
     /**

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -14,6 +14,66 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
 
   private boolean hasError = false;
 
+  /**
+   * Adiciona um identificador único para essa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse id(long id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Adiciona o índice de Complexidade de Gestão médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse icg(Double icg) {
+    this.data.meanICG = icg;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de esforço docente médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse ied(Double ied) {
+    this.data.meanIED = ied;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de adequação da formação docente médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse afd(Double afd) {
+    this.data.meanAFD = afd;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de regularidade docente médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse ird(Double ird) {
+    this.data.meanIRD = ird;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de distorção idade série médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse tdi(Double tdi) {
+    this.data.meanTDI = tdi;
+    return this;
+  }
+
   @Override
   protected void handleError() {
     this.hasError = true;
@@ -43,8 +103,8 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
 
     @JsonUnwrapped
     private Map<String, Object> others;
-    @JsonProperty("efd")
-    private double meanEFD; // esforço docente médio
+    @JsonProperty("ied")
+    private double meanIED; // esforço docente médio
     @JsonProperty("ird")
     private double meanIRD; // regularidade docente média
     @JsonProperty("tdi")

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -2,6 +2,7 @@ package edu.apigestor.entity.response;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -36,44 +37,48 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o índice de Complexidade de Gestão médio.
    *
-   * @param icg ICG médio.
+   * @param icg      ICG médio.
+   * @param category indica qual classe de gestão esse valor se encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public HomeDadosResponse icg(Double icg) {
-    this.data.meanICG = icg;
+  public HomeDadosResponse icg(Double icg, String category) {
+    this.data.addMeanICG(icg, category);
     return this;
   }
 
   /**
    * Adiciona o indicador de esforço docente médio.
    *
-   * @param ied IED médio.
+   * @param ied      IED médio.
+   * @param category indica qual classe de esforço docente esse valor se encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public HomeDadosResponse ied(Double ied) {
-    this.data.meanIED = ied;
+  public HomeDadosResponse ied(Double ied, String category) {
+    this.data.addMeanIED(ied, category);
     return this;
   }
 
   /**
    * Adiciona o indicador de adequação da formação docente médio.
    *
-   * @param afd AFD médio.
+   * @param afd      AFD médio.
+   * @param category indica qual classe da adequação de formação docente esse valor se encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public HomeDadosResponse afd(Double afd) {
-    this.data.meanAFD = afd;
+  public HomeDadosResponse afd(Double afd, String category) {
+    this.data.addMeanAFD(afd, category);
     return this;
   }
 
   /**
    * Adiciona o indicador de regularidade docente médio.
    *
-   * @param ird IRD médio.
+   * @param ird      IRD médio.
+   * @param category indica qual classe do indicador de regularidade esse valor se encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public HomeDadosResponse ird(Double ird) {
-    this.data.meanIRD = ird;
+  public HomeDadosResponse ird(Double ird, String category) {
+    this.data.addMeanIRD(ird, category);
     return this;
   }
 
@@ -84,7 +89,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public HomeDadosResponse tdi(Double tdi) {
-    this.data.meanTDI = tdi;
+    this.data.addMeanTDI(tdi);
     return this;
   }
 
@@ -125,14 +130,67 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
     @JsonAnyGetter
     private Map<String, Object> others;
     @JsonProperty("ied")
-    private Double meanIED; // esforço docente médio
+    private Map<String, Object> ied = new HashMap<>();
     @JsonProperty("ird")
-    private Double meanIRD; // regularidade docente média
+    private Map<String, Object> ird = new HashMap<>();
     @JsonProperty("tdi")
-    private Double meanTDI; // distorção idade série média
+    private Map<String, Object> tdi = new HashMap<>();
     @JsonProperty("icg")
-    private Double meanICG; // complexidade de gestão escolar média
+    private Map<String, Object> icg = new HashMap<>();
     @JsonProperty("afd")
-    private Double meanAFD; // adequação de formação docente média
+    private Map<String, Object> afd = new HashMap<>();
+
+    /**
+     * Esse método adiciona uma média do IED nos dados da resposta.
+     *
+     * @param meanIED  IED médio.
+     * @param category categoria.
+     */
+    private void addMeanIED(Double meanIED, String category) {
+      this.ied.put("mean", meanIED);
+      this.ied.put("meanCategory", category);
+    }
+
+    /**
+     * Esse método adiciona uma média do IRD nos dados da resposta.
+     *
+     * @param meanIRD  IRD médio.
+     * @param category categoria.
+     */
+    private void addMeanIRD(Double meanIRD, String category) {
+      this.ird.put("mean", meanIRD);
+      this.ied.put("meanCategory", category);
+    }
+
+    /**
+     * Esse método adiciona uma média do ICG nos dados da resposta.
+     *
+     * @param meanICG  ICG médio.
+     * @param category categoria.
+     */
+    private void addMeanICG(Double meanICG, String category) {
+      this.icg.put("mean", meanICG);
+      this.ied.put("meanCategory", category);
+    }
+
+    /**
+     * Esse método adiciona uma média do AFD nos dados da resposta.
+     *
+     * @param meanAFD  AFD médio.
+     * @param category categoria.
+     */
+    private void addMeanAFD(Double meanAFD, String category) {
+      this.afd.put("mean", meanAFD);
+      this.ied.put("meanCategory", category);
+    }
+
+    /**
+     * Esse método adiciona uma média do TDI nos dados da resposta.
+     *
+     * @param meanTDI TDI médio.
+     */
+    private void addMeanTDI(Double meanTDI) {
+      this.tdi.put("mean", meanTDI);
+    }
   }
 }

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -1,7 +1,7 @@
 package edu.apigestor.entity.response;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -116,7 +116,7 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
    */
   private static class HomeDadosData {
 
-    @JsonUnwrapped
+    @JsonAnyGetter
     private Map<String, Object> others;
     @JsonProperty("ied")
     private double meanIED; // esforço docente médio

--- a/src/main/java/edu/apigestor/entity/response/HomeEscolaResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeEscolaResponse.java
@@ -1,0 +1,85 @@
+package edu.apigestor.entity.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para solicitações da Home sobre a lista de
+ * escolas que possui um nome similar ao que foi passado.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see AbstractResponse
+ */
+public class HomeEscolaResponse extends AbstractResponse<List<Map<String, Object>>> {
+
+  private static final String RESOURCE_TYPE = "schoolInfo";
+
+  private final List<String> nameEscolas = new ArrayList<>(); // Armazena os nomes das escolas
+  private final List<Integer> codesINEP = new ArrayList<>(); // Armazena os códigos INEP
+  private final List<Long> ids = new ArrayList<>(); // Armazena os IDs da resposta
+
+  private boolean hasError = false;
+
+  /**
+   * Esse método adiciona as informações de uma escola a resposta.
+   *
+   * @param nameEscola nome da escola.
+   * @param codINEP    código INEP da escola.
+   * @param id         id da escola.
+   */
+  public void addEntry(String nameEscola, int codINEP, long id) {
+    this.nameEscolas.add(nameEscola);
+    this.codesINEP.add(codINEP);
+    this.ids.add(id);
+  }
+
+  @Override
+  protected void handleError() {
+    hasError = true;
+  }
+
+  @Override
+  protected List<Map<String, Object>> buildData() {
+    if (this.hasError) {
+      return null;
+    }
+
+    List<Map<String, Object>> data = new ArrayList<>();
+    int size = this.nameEscolas.size();
+
+    for (int i = 0; i < size; i++) {
+      Map<String, Object> m = new LinkedHashMap<>();
+
+      m.put("type", HomeEscolaResponse.RESOURCE_TYPE);
+      m.put("id", this.ids.get(i));
+
+      SchoolEntry entry = new SchoolEntry();
+      entry.name = this.nameEscolas.get(i);
+      entry.codINEP = this.codesINEP.get(i);
+
+      m.put("attributes", entry);
+
+      data.add(m);
+    }
+
+    return data;
+  }
+
+  /**
+   * Define os dados que compõem uma resposta para a Home (identificação da escola).
+   *
+   * @author moesiof
+   * @version 1.0
+   */
+  private static class SchoolEntry {
+
+    @JsonProperty("name")
+    private String name; // Nome da escola
+    @JsonProperty("inep")
+    private int codINEP; // Código INEP da escola
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/IdebEstadualResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebEstadualResponse.java
@@ -14,8 +14,9 @@ public class IdebEstadualResponse extends IdebResponse {
   private String state;
 
   /**
-   * Adiciona um estado para essa resposta.
+   * Adiciona um estado (UF) para essa resposta.
    *
+   * @param state nome do estado/unidade federativa.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public IdebEstadualResponse state(String state) {

--- a/src/main/java/edu/apigestor/entity/response/IdebEstadualResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebEstadualResponse.java
@@ -1,0 +1,30 @@
+package edu.apigestor.entity.response;
+
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para para solicitações do Ideb a nível regional.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see IdebResponse
+ */
+public class IdebEstadualResponse extends IdebResponse {
+
+  private String state;
+
+  /**
+   * Adiciona um estado para essa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public IdebEstadualResponse state(String state) {
+    this.state = state;
+    return this;
+  }
+
+  @Override
+  protected Map<String, Object> additionalAttributes() {
+    return Map.of("state", this.state);
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/IdebResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebResponse.java
@@ -2,6 +2,7 @@ package edu.apigestor.entity.response;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -37,7 +38,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public IdebResponse idebIniciais(Double idebIniciais) {
-    this.data.idebInicias = idebIniciais;
+    this.data.addMeanIdebInicial(idebIniciais);
     return this;
   }
 
@@ -47,7 +48,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public IdebResponse idebFinais(Double idebFinais) {
-    this.data.idebFinais = idebFinais;
+    this.data.addMeanIdebFinal(idebFinais);
     return this;
   }
 
@@ -89,8 +90,27 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
     private Map<String, Object> others;
 
     @JsonProperty("idebIniciais")
-    private Double idebInicias; // ideb dos anos incias
+    private Map<String, Object> idebInicias = new HashMap<>();
     @JsonProperty("idebFinais")
-    private Double idebFinais; // ideb dos anos finais
+    private Map<String, Object> idebFinais = new HashMap<>();
+
+    /**
+     * Esse método adiciona uma média do IDEB dos anos iniciais nos dados da resposta.
+     *
+     * @param meanIdebInicial Ideb médio dos anos iniciais.
+     */
+    public void addMeanIdebInicial(Double meanIdebInicial) {
+      this.idebInicias.put("mean", meanIdebInicial);
+    }
+
+    /**
+     * Esse método adiciona uma média do IDEB dos anos iniciais nos dados da resposta.
+     *
+     * @param meanIdebFinal Ideb médio dos anos finais.
+     */
+    public void addMeanIdebFinal(Double meanIdebFinal) {
+      this.idebFinais.put("mean", meanIdebFinal);
+    }
+
   }
 }

--- a/src/main/java/edu/apigestor/entity/response/IdebResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebResponse.java
@@ -1,0 +1,51 @@
+package edu.apigestor.entity.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class IdebResponse extends AbstractResponse<Map<String, Object>> {
+
+  private static final String RESOURCE_TYPE = "idebData";
+
+  private final IdebData data = new IdebData();
+  private long id; // identificar da resposta
+  private boolean hasError = false;
+
+  @Override
+  protected void handleError() {
+    this.hasError = true;
+  }
+
+  @Override
+  protected Map<String, Object> buildData() {
+    if (this.hasError) {
+      return null;
+    }
+
+    Map<String, Object> data = new LinkedHashMap<>();
+
+    data.put("type", IdebResponse.RESOURCE_TYPE);
+    data.put("id", this.id);
+
+    this.data.others = this.additionalAttributes();
+
+    data.put("attributes", this.data);
+
+    return data;
+  }
+
+  protected abstract Map<String, Object> additionalAttributes();
+
+  private static class IdebData {
+
+    @JsonUnwrapped
+    private Map<String, Object> others;
+
+    @JsonProperty("idebIniciais")
+    private double idebInicias; // ideb dos anos incias
+    @JsonProperty("idebFinais")
+    private double idebFinais; // ideb dos anos finais
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/IdebResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebResponse.java
@@ -90,7 +90,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
     private Map<String, Object> others;
 
     @JsonProperty("idebIniciais")
-    private Map<String, Object> idebInicias = new HashMap<>();
+    private Map<String, Object> idebIniciais = new HashMap<>();
     @JsonProperty("idebFinais")
     private Map<String, Object> idebFinais = new HashMap<>();
 
@@ -100,7 +100,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
      * @param meanIdebInicial Ideb médio dos anos iniciais.
      */
     public void addMeanIdebInicial(Double meanIdebInicial) {
-      this.idebInicias.put("mean", meanIdebInicial);
+      this.idebIniciais.put("mean", meanIdebInicial);
     }
 
     /**

--- a/src/main/java/edu/apigestor/entity/response/IdebResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebResponse.java
@@ -36,7 +36,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
    *
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public IdebResponse idebIniciais(double idebIniciais) {
+  public IdebResponse idebIniciais(Double idebIniciais) {
     this.data.idebInicias = idebIniciais;
     return this;
   }
@@ -46,7 +46,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
    *
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public IdebResponse idebFinais(double idebFinais) {
+  public IdebResponse idebFinais(Double idebFinais) {
     this.data.idebFinais = idebFinais;
     return this;
   }
@@ -89,8 +89,8 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
     private Map<String, Object> others;
 
     @JsonProperty("idebIniciais")
-    private double idebInicias; // ideb dos anos incias
+    private Double idebInicias; // ideb dos anos incias
     @JsonProperty("idebFinais")
-    private double idebFinais; // ideb dos anos finais
+    private Double idebFinais; // ideb dos anos finais
   }
 }

--- a/src/main/java/edu/apigestor/entity/response/IdebResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebResponse.java
@@ -5,6 +5,14 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>Essa classe representa uma resposta para solicitações do Ideb em diferentes níveis
+ * (Nacional, Regional ou Estadual).</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see AbstractResponse
+ */
 public abstract class IdebResponse extends AbstractResponse<Map<String, Object>> {
 
   private static final String RESOURCE_TYPE = "idebData";
@@ -12,6 +20,36 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
   private final IdebData data = new IdebData();
   private long id; // identificar da resposta
   private boolean hasError = false;
+
+  /**
+   * Adiciona um identificador único para essa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public IdebResponse id(long id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Adiciona o Ideb dos anos iniciais.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public IdebResponse idebIniciais(double idebIniciais) {
+    this.data.idebInicias = idebIniciais;
+    return this;
+  }
+
+  /**
+   * Adiciona o Ideb dos anos finais.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public IdebResponse idebFinais(double idebFinais) {
+    this.data.idebFinais = idebFinais;
+    return this;
+  }
 
   @Override
   protected void handleError() {
@@ -38,6 +76,13 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
 
   protected abstract Map<String, Object> additionalAttributes();
 
+  /**
+   * Define os dados que compõem uma resposta sobre o Ideb de uma determinada entidade (região,
+   * país, escola, etc).
+   *
+   * @author moesiof
+   * @version 1.0
+   */
   private static class IdebData {
 
     @JsonUnwrapped

--- a/src/main/java/edu/apigestor/entity/response/IdebResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/IdebResponse.java
@@ -1,7 +1,7 @@
 package edu.apigestor.entity.response;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -85,7 +85,7 @@ public abstract class IdebResponse extends AbstractResponse<Map<String, Object>>
    */
   private static class IdebData {
 
-    @JsonUnwrapped
+    @JsonAnyGetter
     private Map<String, Object> others;
 
     @JsonProperty("idebIniciais")

--- a/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
@@ -1,0 +1,193 @@
+package edu.apigestor.entity.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados para o Painel de Escolas.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see AbstractResponse
+ */
+public final class PainelEscolaResponse extends AbstractResponse<Map<String, Object>> {
+
+  private final PainelEscolaData data = new PainelEscolaData();
+  private long id; // identificar da resposta
+  private boolean hasError = false;
+
+  /**
+   * Adiciona um identificador único para essa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse id(long id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Adiciona o nome da escola.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse nameEscola(String nameEscola) {
+    this.data.nameEscola = nameEscola;
+    return this;
+  }
+
+  /**
+   * Adiciona o código INEP,.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse codINEP(long codINEP) {
+    this.data.codINEP = codINEP;
+    return this;
+  }
+
+  /**
+   * Adiciona o endereço.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse address(String address) {
+    this.data.address = address;
+    return this;
+  }
+
+  /**
+   * Adiciona um número para contato.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse phoneNumber(String phoneNumber) {
+    this.data.phoneNumber = phoneNumber;
+    return this;
+  }
+
+  /**
+   * Adiciona o Ideb médio dos anos inicias.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse idebIniciais(Double idebIniciais) {
+    this.data.idebIniciais = idebIniciais;
+    return this;
+  }
+
+  /**
+   * Adiciona o Ideb médio dos anos finais.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse idebFinais(Double idebFinais) {
+    this.data.idebFinais = idebFinais;
+    return this;
+  }
+
+  /**
+   * Adiciona a quantidade de matrículas.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse nMatriculas(Long nMatriculas) {
+    this.data.nMatriculas = nMatriculas;
+    return this;
+  }
+
+  /**
+   * Adiciona a quantidade de docentes.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse nDocentes(Long nDocentes) {
+    this.data.nDocentes = nDocentes;
+    return this;
+  }
+
+  /**
+   * Adiciona o índice de Complexidade de Gestão.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse icg(Integer icg) {
+    this.data.icg = icg;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de esforço docente.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse ied(Integer ied) {
+    this.data.ied = ied;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de adequação da formação docente.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public PainelEscolaResponse afd(Integer afd) {
+    this.data.afd = afd;
+    return this;
+  }
+
+  @Override
+  protected void handleError() {
+    this.hasError = true;
+  }
+
+  @Override
+  protected Map<String, Object> buildData() {
+    if (this.hasError) {
+      return null; // Caso possua algum erro, não devemos retornar dados.
+    }
+
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("id", Long.toString(this.id));
+    data.put("type", "schoolData");
+    data.put("attributes", this.data); // Adiciona todos os dados nos atributos
+
+    return data;
+  }
+
+  /**
+   * Define os dados que compõem uma resposta para o Paindel de Escola.
+   *
+   * @author moesiof
+   * @version 1.0
+   */
+  private static class PainelEscolaData {
+
+    // Informações da escola
+    @JsonProperty("name")
+    private String nameEscola;
+    @JsonProperty("inep")
+    private long codINEP;
+    @JsonProperty("address")
+    private String address;
+    @JsonProperty("phone")
+    private String phoneNumber;
+
+    // Indicadores educacionais da escola
+    @JsonProperty("idebIniciais")
+    private Double idebIniciais;
+    @JsonProperty("idebFinais")
+    private Double idebFinais;
+    @JsonProperty("matriculas")
+    private Long nMatriculas; // Quantidade de matrículas
+    @JsonProperty("docentes")
+    private Long nDocentes; // Quantidade de docentes
+    @JsonProperty("icg")
+    private Integer icg; // Indicador da complexidade de gestão
+    @JsonProperty("ied")
+    private Integer ied; // Indicador do esforço docente
+    @JsonProperty("afd")
+    private Integer afd; // Indicador de adequação da formação docente
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
@@ -13,6 +13,8 @@ import java.util.Map;
  */
 public final class PainelEscolaResponse extends AbstractResponse<Map<String, Object>> {
 
+  private static final String RESOURCE_TYPE = "schoolData";
+
   private final PainelEscolaData data = new PainelEscolaData();
   private long id; // identificar da resposta
   private boolean hasError = false;
@@ -38,7 +40,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   }
 
   /**
-   * Adiciona o código INEP,.
+   * Adiciona o código INEP.
    *
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
@@ -149,15 +151,15 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
     }
 
     Map<String, Object> data = new LinkedHashMap<>();
-    data.put("id", Long.toString(this.id));
-    data.put("type", "schoolData");
+    data.put("id", this.id);
+    data.put("type", PainelEscolaResponse.RESOURCE_TYPE);
     data.put("attributes", this.data); // Adiciona todos os dados nos atributos
 
     return data;
   }
 
   /**
-   * Define os dados que compõem uma resposta para o Paindel de Escola.
+   * Define os dados que compõem uma resposta para o Painel de Escola.
    *
    * @author moesiof
    * @version 1.0

--- a/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
@@ -1,6 +1,7 @@
 package edu.apigestor.entity.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -81,7 +82,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse idebIniciais(Double idebIniciais) {
-    this.data.idebIniciais = idebIniciais;
+    this.data.addMeanIdebInicial(idebIniciais);
     return this;
   }
 
@@ -92,7 +93,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse idebFinais(Double idebFinais) {
-    this.data.idebFinais = idebFinais;
+    this.data.addMeanIdebFinal(idebFinais);
     return this;
   }
 
@@ -121,33 +122,37 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o índice de Complexidade de Gestão médio para essa escola.
    *
-   * @param icg ICG médio.
+   * @param icg      ICG médio.
+   * @param category indica qual classe do indicador de complexidade de gestão esse valor se
+   *                 encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse icg(Double icg) {
-    this.data.icg = icg;
+  public PainelEscolaResponse icg(Double icg, String category) {
+    this.data.addMeanICG(icg, category);
     return this;
   }
 
   /**
    * Adiciona o indicador de esforço docente médio para essa escola.
    *
-   * @param ied IED médio.
+   * @param ied      IED médio.
+   * @param category indica qual classe do indicador de esforço docente esse valor se encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse ied(Double ied) {
-    this.data.ied = ied;
+  public PainelEscolaResponse ied(Double ied, String category) {
+    this.data.addMeanIED(ied, category);
     return this;
   }
 
   /**
    * Adiciona o indicador de adequação da formação docente média para essa escola.
    *
-   * @param afd AFD médio.
+   * @param afd      AFD médio.
+   * @param category indica qual classe da adequação de formação docente esse valor se encontra.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse afd(Double afd) {
-    this.data.afd = afd;
+  public PainelEscolaResponse afd(Double afd, String category) {
+    this.data.addMeanAFD(afd, category);
     return this;
   }
 
@@ -190,18 +195,71 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
 
     // Indicadores educacionais da escola
     @JsonProperty("idebIniciais")
-    private Double idebIniciais;
+    private Map<String, Object> idebIniciais = new HashMap<>();
     @JsonProperty("idebFinais")
-    private Double idebFinais;
+    private Map<String, Object> idebFinais = new HashMap<>();
     @JsonProperty("matriculas")
-    private Integer nMatriculas; // Quantidade de matrículas
+    private Integer nMatriculas;
     @JsonProperty("docentes")
-    private Integer nDocentes; // Quantidade de docentes
+    private Integer nDocentes;
     @JsonProperty("icg")
-    private Double icg; // Indicador da complexidade de gestão
+    private Map<String, Object> icg = new HashMap<>();
     @JsonProperty("ied")
-    private Double ied; // Indicador do esforço docente
+    private Map<String, Object> ied = new HashMap<>();
     @JsonProperty("afd")
-    private Double afd; // Indicador de adequação da formação docente
+    private Map<String, Object> afd = new HashMap<>();
+
+    /**
+     * Esse método adiciona uma média do IDEB dos anos iniciais nos dados da resposta.
+     *
+     * @param meanIdebInicial Ideb médio dos anos iniciais.
+     */
+    public void addMeanIdebInicial(Double meanIdebInicial) {
+      this.idebIniciais.put("mean", meanIdebInicial);
+    }
+
+    /**
+     * Esse método adiciona uma média do IDEB dos anos iniciais nos dados da resposta.
+     *
+     * @param meanIdebFinal Ideb médio dos anos finais.
+     */
+    public void addMeanIdebFinal(Double meanIdebFinal) {
+      this.idebFinais.put("mean", meanIdebFinal);
+    }
+
+    /**
+     * Esse método adiciona uma média do IED nos dados da resposta.
+     *
+     * @param meanIED  IED médio.
+     * @param category categoria.
+     */
+    private void addMeanIED(Double meanIED, String category) {
+      this.ied.put("mean", meanIED);
+      this.ied.put("meanCategory", category);
+    }
+
+    /**
+     * Esse método adiciona uma média do ICG nos dados da resposta.
+     *
+     * @param meanICG  ICG médio.
+     * @param category categoria.
+     */
+    private void addMeanICG(Double meanICG, String category) {
+      this.icg.put("mean", meanICG);
+      this.ied.put("meanCategory", category);
+    }
+
+    /**
+     * Esse método adiciona uma média do AFD nos dados da resposta.
+     *
+     * @param meanAFD  AFD médio.
+     * @param category categoria.
+     */
+    private void addMeanAFD(Double meanAFD, String category) {
+      this.afd.put("mean", meanAFD);
+      this.ied.put("meanCategory", category);
+    }
+
+
   }
 }

--- a/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/PainelEscolaResponse.java
@@ -22,6 +22,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona um identificador único para essa resposta.
    *
+   * @param id identificador.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse id(long id) {
@@ -32,6 +33,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o nome da escola.
    *
+   * @param nameEscola nome da escola.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse nameEscola(String nameEscola) {
@@ -42,6 +44,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o código INEP.
    *
+   * @param codINEP código INEP (código da escola).
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse codINEP(long codINEP) {
@@ -52,6 +55,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o endereço.
    *
+   * @param address localização dessa escola.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse address(String address) {
@@ -62,6 +66,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona um número para contato.
    *
+   * @param phoneNumber contato da escola (telefone).
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse phoneNumber(String phoneNumber) {
@@ -72,6 +77,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o Ideb médio dos anos inicias.
    *
+   * @param idebIniciais IDEB médio dos anos iniciais.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse idebIniciais(Double idebIniciais) {
@@ -82,6 +88,7 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona o Ideb médio dos anos finais.
    *
+   * @param idebFinais IDEB médio dos anos finais.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
   public PainelEscolaResponse idebFinais(Double idebFinais) {
@@ -92,9 +99,10 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona a quantidade de matrículas.
    *
+   * @param nMatriculas quantidade de matrículas.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse nMatriculas(Long nMatriculas) {
+  public PainelEscolaResponse nMatriculas(Integer nMatriculas) {
     this.data.nMatriculas = nMatriculas;
     return this;
   }
@@ -102,39 +110,43 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
   /**
    * Adiciona a quantidade de docentes.
    *
+   * @param nDocentes quantidade de docentes.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse nDocentes(Long nDocentes) {
+  public PainelEscolaResponse nDocentes(Integer nDocentes) {
     this.data.nDocentes = nDocentes;
     return this;
   }
 
   /**
-   * Adiciona o índice de Complexidade de Gestão.
+   * Adiciona o índice de Complexidade de Gestão médio para essa escola.
    *
+   * @param icg ICG médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse icg(Integer icg) {
+  public PainelEscolaResponse icg(Double icg) {
     this.data.icg = icg;
     return this;
   }
 
   /**
-   * Adiciona o indicador de esforço docente.
+   * Adiciona o indicador de esforço docente médio para essa escola.
    *
+   * @param ied IED médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse ied(Integer ied) {
+  public PainelEscolaResponse ied(Double ied) {
     this.data.ied = ied;
     return this;
   }
 
   /**
-   * Adiciona o indicador de adequação da formação docente.
+   * Adiciona o indicador de adequação da formação docente média para essa escola.
    *
+   * @param afd AFD médio.
    * @return essa mesma resposta, permitindo <i>method chaining</i>.
    */
-  public PainelEscolaResponse afd(Integer afd) {
+  public PainelEscolaResponse afd(Double afd) {
     this.data.afd = afd;
     return this;
   }
@@ -182,14 +194,14 @@ public final class PainelEscolaResponse extends AbstractResponse<Map<String, Obj
     @JsonProperty("idebFinais")
     private Double idebFinais;
     @JsonProperty("matriculas")
-    private Long nMatriculas; // Quantidade de matrículas
+    private Integer nMatriculas; // Quantidade de matrículas
     @JsonProperty("docentes")
-    private Long nDocentes; // Quantidade de docentes
+    private Integer nDocentes; // Quantidade de docentes
     @JsonProperty("icg")
-    private Integer icg; // Indicador da complexidade de gestão
+    private Double icg; // Indicador da complexidade de gestão
     @JsonProperty("ied")
-    private Integer ied; // Indicador do esforço docente
+    private Double ied; // Indicador do esforço docente
     @JsonProperty("afd")
-    private Integer afd; // Indicador de adequação da formação docente
+    private Double afd; // Indicador de adequação da formação docente
   }
 }


### PR DESCRIPTION
Essa é uma entidade abstrata que representa uma resposta para as solicitações feitas a API. A ideia é seguir algumas das especificações do [JSON:API 1.0](https://jsonapi.org/format/1.0/) acerca da estrutura de JSONs que serão consumidos por diferentes APIs.

A estrutura básica do JSON é a seguinte:

- No _top level_ devem existir ao menos um dos elementos `data`, `meta` e `error`. Especificamente, se existe o elemento `error` não deve existir o elemento `data`. Para permitir esse comportamento, a classe `AbstractResponse` permite que subclasses sobrescrevam métodos que tratam a adição de erros e/ou meta-dados.
- O elemento `data` pode ser um único recurso ou uma coleção de recursos.  Independente do caso, todo recurso deve possuir ao menos um `id` e um `type`. Abaixo um exemplo seguindo as especificações onde a API retornou um recurso utilizado pela _home_ para exibir dados da educação brasileira a nível nacional.

```json
{
  "data": {
    "type": "eduData",
    "id": 1,
    "attributes": {
      "ied": {
        "meanCategory": "Docente que tem entre 25 e 300 alunos e atua em um ou dois turnos em uma única escola e etapa.",
        "mean": 2.88
      },
      "ird": {
        "meanCategory": "Média-baixa",
        "mean": 2.9615
      },
      "tdi": {
        "mean": 16.2
      },
      "icg": {
        "meanCategory": null,
        "mean": null
      },
      "afd": {
        "meanCategory": "Docentes com licenciatura em área diferente daquela que leciona, ou com bacharelado nas disciplinas da base curricular comum e complementação pedagógica concluída em área diferente daquela que leciona.",
        "mean": 2.062
      },
      "country": "Brasil"
    }
  }
}
```

A classe `AbstractResponse` facilita a geração das respostas nesse formato e permite que subclasses escolham especificamente o tipo de resposta através do uso de _generics_.