### PR TITLE
feat: add entity HomeDadosResponse

### DIFF
--- a/src/main/java/edu/apigestor/entity/response/HomeDadosNacionalResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosNacionalResponse.java
@@ -1,0 +1,31 @@
+package edu.apigestor.entity.response;
+
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados gerais sobre a educação
+ * brasileira a nível nacional.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see HomeDadosResponse
+ */
+public class HomeDadosNacionalResponse extends HomeDadosResponse {
+
+  private String country = "Brasil"; // País padrão da resposta.
+
+  /**
+   * Adiciona o país dessa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosNacionalResponse country(String country) {
+    this.country = country;
+    return this;
+  }
+
+  @Override
+  protected Map<String, Object> additionalAttributes() {
+    return Map.of("country", this.country);
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosRegionalResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosRegionalResponse.java
@@ -1,0 +1,31 @@
+package edu.apigestor.entity.response;
+
+import java.util.Map;
+
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados gerais sobre a educação
+ * brasileira a nível regional.</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see HomeDadosResponse
+ */
+public class HomeDadosRegionalResponse extends HomeDadosResponse {
+
+  private String region;
+
+  /**
+   * Adiciona a região dessa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosRegionalResponse region(String region) {
+    this.region = region;
+    return this;
+  }
+
+  @Override
+  protected Map<String, Object> additionalAttributes() {
+    return Map.of("region", this.region);
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -5,6 +5,14 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>Essa classe representa uma resposta para solicitações de dados gerais sobre a educação
+ * brasileira em algum nível (Nacional, Regional ou Estadual).</p>
+ *
+ * @author moesiof
+ * @version 1.0
+ * @see AbstractResponse
+ */
 public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Object>> {
 
   private static final String RESOURCE_TYPE = "eduData";
@@ -99,6 +107,13 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
 
   protected abstract Map<String, Object> additionalAttributes();
 
+  /**
+   * Define os dados que compõem uma resposta sobre os dados da educação brasileira. Todos
+   * representam uma média.
+   *
+   * @author moesiof
+   * @version 1.0
+   */
   private static class HomeDadosData {
 
     @JsonUnwrapped

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -1,0 +1,57 @@
+package edu.apigestor.entity.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Object>> {
+
+  private static final String RESOURCE_TYPE = "eduData";
+
+  private final HomeDadosData data = new HomeDadosData();
+  private long id; // identificar da resposta
+
+  private boolean hasError = false;
+
+  @Override
+  protected void handleError() {
+    this.hasError = true;
+  }
+
+  @Override
+  protected Map<String, Object> buildData() {
+    if (this.hasError) {
+      return null;
+    }
+
+    Map<String, Object> data = new LinkedHashMap<>();
+
+    data.put("type", HomeDadosResponse.RESOURCE_TYPE);
+    data.put("id", this.id);
+
+    this.data.others = this.additionalAttributes();
+
+    data.put("attributes", this.data);
+
+    return data;
+  }
+
+  protected abstract Map<String, Object> additionalAttributes();
+
+  private static class HomeDadosData {
+
+    @JsonUnwrapped
+    private Map<String, Object> others;
+    @JsonProperty("efd")
+    private double meanEFD; // esforço docente médio
+    @JsonProperty("ird")
+    private double meanIRD; // regularidade docente média
+    @JsonProperty("tdi")
+    private double meanTDI; // distorção idade série média
+    @JsonProperty("icg")
+    private double meanICG; // complexidade de gestão escolar média
+    @JsonProperty("afd")
+    private double meanAFD; // adequação de formação docente média
+  }
+}

--- a/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
+++ b/src/main/java/edu/apigestor/entity/response/HomeDadosResponse.java
@@ -14,6 +14,66 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
 
   private boolean hasError = false;
 
+  /**
+   * Adiciona um identificador único para essa resposta.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse id(long id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Adiciona o índice de Complexidade de Gestão médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse icg(Double icg) {
+    this.data.meanICG = icg;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de esforço docente médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse ied(Double ied) {
+    this.data.meanIED = ied;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de adequação da formação docente médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse afd(Double afd) {
+    this.data.meanAFD = afd;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de regularidade docente médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse ird(Double ird) {
+    this.data.meanIRD = ird;
+    return this;
+  }
+
+  /**
+   * Adiciona o indicador de distorção idade série médio.
+   *
+   * @return essa mesma resposta, permitindo <i>method chaining</i>.
+   */
+  public HomeDadosResponse tdi(Double tdi) {
+    this.data.meanTDI = tdi;
+    return this;
+  }
+
   @Override
   protected void handleError() {
     this.hasError = true;
@@ -43,8 +103,8 @@ public abstract class HomeDadosResponse extends AbstractResponse<Map<String, Obj
 
     @JsonUnwrapped
     private Map<String, Object> others;
-    @JsonProperty("efd")
-    private double meanEFD; // esforço docente médio
+    @JsonProperty("ied")
+    private double meanIED; // esforço docente médio
     @JsonProperty("ird")
     private double meanIRD; // regularidade docente média
     @JsonProperty("tdi")


### PR DESCRIPTION
Adicionando classes de resposta para  _home_ que mostra dados gerais sobre a educação brasileira.

Estrutura do JSON básico da classe `HomeDadosResponse`:

```json
{
 "meta": {},
 "error": {},
 "data": {
  "type": "eduData",
  "id": 0,
  "attributes": {
   "ied": 0.0,
   "ird": 0.0,
   "tdi": 0.0,
   "icg": 0.0,
   "afd": 0.0
  }
 }
}
```

Subclasses adicionam informações auxiliares em `attributes` (i.e., `country`, `region` ou `state`), todavia a estrutura continua a mesma.

